### PR TITLE
add `convertcase` option to disable attribute name conversion to camelCase

### DIFF
--- a/lib/postgresql-store.js
+++ b/lib/postgresql-store.js
@@ -17,6 +17,7 @@ module.exports = function (opts) {
 
   opts.minwait = opts.minwait || MIN_WAIT
   opts.maxwait = opts.maxwait || MAX_WAIT
+  opts.convertcase = ('convertcase' in opts) ? opts.convertcase : true
 
   var minwait
 
@@ -286,7 +287,8 @@ module.exports = function (opts) {
     var obj = {}
     for (var attr in row) {
       if (row.hasOwnProperty(attr)) {
-        obj[RelationalStore.snakeToCamelCase(attr)] = row[attr]
+        if (opts.convertcase) attr = RelationalStore.snakeToCamelCase(attr)
+        obj[attr] = row[attr]
       }
     }
     return obj


### PR DESCRIPTION
I find it easier to think about entities when the database columns and JS object properties are the same, so this conversion took me by surprise and even caused a few "column specified more than once" errors.

This adds an option to disable the conversion when loading entities from the database. It defaults to the current behavior.