### PR TITLE
Backward compatible test sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,19 @@ Supports Seneca versions from **0.6.5** up to **1.4.0**
 
 ### Query Support
 
-The standard Seneca query format is supported. See the [seneca-standard-store][standard-store] plugin for more details.
+The standard Seneca query format is supported. See the [seneca-standard-query][standard-query] plugin for more details.
 
-## Extend Query Support
+## Extended Query Support
 
 By using the [seneca-store-query][store-query] plugin its query capabilities can be extended. See the plugin page for more details.
+
+### Backward compatibility
+
+Internal CamelCase to snake_case column names conversion was removed.
+
+To update from seneca-postgres-store 1.x to 2.x on systems built with seneca-postgres-store 1.x you must provide to the plugin through its options the functions that do the CamelCase to snake_case conversion and back.
+
+See the [seneca-standard-query][standard-query] plugin for more details.
 
 ## Limits
 
@@ -122,5 +130,5 @@ examples, extra testing, or new features please get in touch.
 [codeclimate-url]: https://codeclimate.com/github/senecajs/seneca-postgres-store
 [gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
 [gitter-url]: https://gitter.im/senecajs/seneca
-[standard-store]: https://github.com/senecajs/seneca-standard-store
+[standard-query]: https://github.com/senecajs/seneca-standard-query
 [store-query]: https://github.com/senecajs/seneca-store-query

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ seneca-postgres-store
 [![Gitter][gitter-badge]][gitter-url]
 
 seneca-postgres-store is a [PostgreSQL][postgresqlorg] database plugin for the [Seneca][seneca] MVP toolkit. The plugin is using the [node-postgres][nodepg] driver.
-For query generation it uses internally the [seneca-standard-store][standard-store] plugin and the standard functionality can be extended by using the [seneca-store-query][store-query] plugin.
+For query generation it uses internally the [seneca-standard-query][standard-query] plugin and the standard functionality can be extended by using the [seneca-store-query][store-query] plugin.
 
 Usage:
 
@@ -64,13 +64,28 @@ The standard Seneca query format is supported. See the [seneca-standard-query][s
 
 By using the [seneca-store-query][store-query] plugin its query capabilities can be extended. See the plugin page for more details.
 
-### Backward compatibility
+## Column name transformation, backward compatibility
 
-Internal CamelCase to snake_case column names conversion was removed.
+In seneca-postgres-store 2.0 the internal CamelCase to snake_case column names conversion was removed.
 
-To update from seneca-postgres-store 1.x to 2.x on systems built with seneca-postgres-store 1.x you must provide to the plugin through its options the functions that do the CamelCase to snake_case conversion and back.
+To update from seneca-postgres-store 1.x to 2.x on systems built with seneca-postgres-store 1.x you must provide to the plugin through its options the functions that do the CamelCase to snake_case conversion and back. Any other name transformations to and from database column name can be also made with these. Example:
 
-See the [seneca-standard-query][standard-query] plugin for more details.
+```js
+var DefaultConfig = {
+...
+  fromColumnName: function (attr) {
+    // apply some conversion on column names
+    return attr.toUpperCase()
+  },
+  toColumnName: function (attr) {
+    // convert back column names
+    return attr.toLowerCase()
+  }
+}
+seneca.use(require('seneca-postgres-store'), DefaultConfig)
+```
+
+For a fully functional CamelCase to snake_case implementation sample please look in the postgres.test.js at the 'Column Names conversions' test code.
 
 ## Limits
 

--- a/docker/dbschema.sql
+++ b/docker/dbschema.sql
@@ -15,8 +15,11 @@ CREATE TABLE foo
   id character varying PRIMARY KEY,
   p1 character varying,
   p2 character varying,
-  p3 character varying
+  p3 character varying,
+  "fooBar" character varying,
+  bar_foo character varying
 );
+
 ALTER TABLE foo OWNER TO senecatest;
 
 CREATE TABLE moon_bar

--- a/test/postgres.test.js
+++ b/test/postgres.test.js
@@ -481,9 +481,10 @@ describe('Column Names conversions', function () {
     it('should not alter CamelCase column names', function (done) {
       var foo = siDefault.make('foo')
 
-      foo.list$({native$: 'SELECT * FROM foo where "fooBar" = \'fooBar\''}, function (err, res) {
+      foo.list$({native$: 'SELECT * FROM foo WHERE "fooBar" = \'fooBar\''}, function (err, res) {
         expect(err).to.not.exist()
         expect(res.length).to.equal(1)
+        expect(res[0].fooBar).to.equal('fooBar')
 
         done()
       })
@@ -492,9 +493,10 @@ describe('Column Names conversions', function () {
     it('should not alter snake_case column names', function (done) {
       var foo = siDefault.make('foo')
 
-      foo.list$({native$: 'SELECT * FROM foo where bar_foo = \'bar_foo\''}, function (err, res) {
+      foo.list$({native$: 'SELECT * FROM foo WHERE bar_foo = \'bar_foo\''}, function (err, res) {
         expect(err).to.not.exist()
         expect(res.length).to.equal(1)
+        expect(res[0].bar_foo).to.equal('bar_foo')
 
         done()
       })
@@ -545,9 +547,10 @@ describe('Column Names conversions', function () {
     it('should convert the CamelCase column name to snake case', function (done) {
       var foo = siCustom.make('foo')
 
-      foo.list$({native$: 'SELECT * FROM foo where "bar_foo" = \'fooBar\''}, function (err, res) {
+      foo.list$({native$: 'SELECT * FROM foo WHERE "bar_foo" = \'barFoo\''}, function (err, res) {
         expect(err).to.not.exist()
         expect(res.length).to.equal(1)
+        expect(res[0].barFoo).to.equal('barFoo')
 
         done()
       })


### PR DESCRIPTION
Verifies that by default the CamelCase column names are not converted to snake_case
Tests a custom column name converter that converts CamelCase column names to snake_case database columns. This sample will be used to ensure backward compatibility with apps built with 1.x postgres stores.