### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/postgresql-store.js
+++ b/lib/postgresql-store.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var Pg = require('pg')
-var Uuid = require('node-uuid')
+var Uuid = require('uuid')
 var name = 'postgresql-store'
 var actionRole = 'sql'
 

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "annotate": "docco lib/postgresql-store.js -o docs/annotated"
   },
   "dependencies": {
-    "node-uuid": "1.4.7",
     "pg": "5.1.0",
-    "seneca-standard-query": "0.0.5"
+    "seneca-standard-query": "0.0.5",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "seneca": "plugin",

--- a/test/postgres.test.js
+++ b/test/postgres.test.js
@@ -9,7 +9,7 @@ var Code = require('code')
 var expect = Code.expect
 
 var Async = require('async')
-var Uuid = require('node-uuid')
+var Uuid = require('uuid')
 
 var describe = lab.describe
 var before = lab.before


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.