### PR TITLE
Update compatibility with Seneca 3.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 2.3.1 02-10-2017
+
+* Fix `native$` to include `releaseConnection` with client, for use under `seneca@3.4.x`
+
 ## 2.3.0 26-08-2016
 
 * Updated dependencies

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Usage:
 ### Seneca compatibility
 Supports Seneca versions **1.x** - **3.x**
 
+#### Note on Seneca 3.4
+
+In Seneca 3.4.0, the `releaseConnection` function is no longer available as the third parameter and must be accessed from the `client` object.  If you are using this version of seneca, you'll need to update to `seneca-postgres-store@2.3.1`
+
+```js
+// seneca <= 3.3:
+entity.native$((err, client, releaseConnection) => releaseConnection())
+
+// seneca >= 3.4:
+entity.native$((err, client) => client.releaseConnection())
+```
+
 ### Supported functionality
 All Seneca data store supported functionality is implemented in [seneca-store-test](https://github.com/senecajs/seneca-store-test) as a test suite. The tests represent the store functionality specifications.
 
@@ -118,10 +130,10 @@ As with all seneca stores, you can access the native driver, in this case, the `
 Please make sure that you release the connection after using it.
 
 ```
-entity.native$( function (err, client, releaseConnection){
+entity.native$( function (err, client){
   // ... you can use client
   // ... then release connection
-  releaseConnection()
+  client.releaseConnection()
 } )
 ```
 

--- a/lib/postgresql-store.js
+++ b/lib/postgresql-store.js
@@ -286,7 +286,11 @@ module.exports = function (opts) {
     },
 
     native: function (args, done) {
-      Pg.connect(pgConf, done)
+      Pg.connect(pgConf, (err, client, releaseConnection) => {
+        if (err) { return done(err) }
+        client.releaseConnection = releaseConnection
+        done(null, client, releaseConnection)
+      })
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-postgres-store",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Seneca data store plugin for PostgreSQL",
   "main": "lib/postgresql-store.js",
   "author": "Marian Radulescu",
@@ -23,7 +23,8 @@
     "Max Nachlinger (https://github.com/maxnachlinger)",
     "David Cahill (https://github.com/david-cahill)",
     "Hiro Asari (https://github.com/BanzaiMan)",
-    "Christian Savard (https://github.com/savardc)"
+    "Christian Savard (https://github.com/savardc)",
+    "Tyler Waters (https://github.com/tswaters)"
   ],
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/test/postgres.test.js
+++ b/test/postgres.test.js
@@ -100,6 +100,33 @@ describe('Basic Test', function () {
   })
 })
 
+describe('native$', function () {
+  before({}, function (done) {
+    si.use(require('..'), DefaultConfig)
+    si.ready(function () {
+      si.use(require('seneca-store-query'))
+      si.ready(done)
+    })
+  })
+
+  beforeEach(clearDb(si))
+  beforeEach(createEntities(si, 'foo', [{id$: 'foo1'}, {id$: 'foo2'}]))
+
+  it('should function properly', function (done) {
+    si.make('foo').native$(function (err, client) {
+      expect(client.releaseConnection).to.be.function()
+      if (err) { return done(err) }
+      client.query('select id from foo', (err, result) => {
+        if (err) { return done(err) }
+        expect(result.rows).to.exist()
+        expect(result.rows).to.equal([{id: 'foo1'}, {id: 'foo2'}])
+        client.releaseConnection()
+        done()
+      })
+    })
+  })
+})
+
 describe('postgres', function () {
   beforeEach(clearDb(si))
   beforeEach(createEntities(si, 'foo', [{


### PR DESCRIPTION
- update releaseConnection to be passed with client
- still compatible with older seneca versions

Fixes #176

Note - I've updated package.json / readme / changelog with notes about this change... I'm thinking if everything looks good it should be published as-is.  If package versions change these will need to be updated obvs.

This change should be compatible with seneca@3.3 still, but the information would be good to put front/center for those updating to latest versions.